### PR TITLE
Make auto_accept_shared_attachments configurable via variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ module "transit_gateway" {
 | account\_name | Name of the AWS account. | `string` | n/a | yes |
 | allowed\_prefixes | VPC prefixes (CIDRs) to advertise to the Direct Connect gateway. Defaults to the CIDR block of the VPC associated with the Virtual Gateway. To enable drift detection, must be configured. | `list(string)` | `[]` | no |
 | attachment | Create VPC Attachment to Transit Gateway | `bool` | `false` | no |
-| auto\_accept\_shared\_attachments | Whether resource attachment requests are automatically accepted. | `string` | `"disable"` | no |
+| auto\_accept\_shared\_attachments | Whether resource attachment requests are automatically accepted. | `string` | `"enable"` | no |
 | default\_route\_table\_association | Whether resource attachments are automatically associated with the default association route table. Valid values: disable, enable. Default value: enable. | `string` | `"enable"` | no |
 | default\_route\_table\_propagation | Whether resource attachments automatically propagate routes to the default propagation route table. Valid values: disable, enable. Default value: enable. | `string` | `"enable"` | no |
 | direct\_connect\_gateway\_asn | The ASN to be configured on the Amazon side of the connection. The ASN must be in the private range of 64,512 to 65,534 or 4,200,000,000 to 4,294,967,294. | `number` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ module "transit_gateway" {
 | account\_name | Name of the AWS account. | `string` | n/a | yes |
 | allowed\_prefixes | VPC prefixes (CIDRs) to advertise to the Direct Connect gateway. Defaults to the CIDR block of the VPC associated with the Virtual Gateway. To enable drift detection, must be configured. | `list(string)` | `[]` | no |
 | attachment | Create VPC Attachment to Transit Gateway | `bool` | `false` | no |
+| auto\_accept\_shared\_attachments | Whether resource attachment requests are automatically accepted. | `string` | `"disable"` | no |
 | default\_route\_table\_association | Whether resource attachments are automatically associated with the default association route table. Valid values: disable, enable. Default value: enable. | `string` | `"enable"` | no |
 | default\_route\_table\_propagation | Whether resource attachments automatically propagate routes to the default propagation route table. Valid values: disable, enable. Default value: enable. | `string` | `"enable"` | no |
 | direct\_connect\_gateway\_asn | The ASN to be configured on the Amazon side of the connection. The ASN must be in the private range of 64,512 to 65,534 or 4,200,000,000 to 4,294,967,294. | `number` | n/a | yes |

--- a/_variables.tf
+++ b/_variables.tf
@@ -186,6 +186,6 @@ variable "flow_logs_retention" {
 
 variable "auto_accept_shared_attachments" {
   type        = string
-  default     = "disable"
+  default     = "enable"
   description = "Whether resource attachment requests are automatically accepted."
 }

--- a/_variables.tf
+++ b/_variables.tf
@@ -183,3 +183,9 @@ variable "flow_logs_retention" {
   default     = 365
   description = "Retention in days for Transit Gateway Flow Logs CloudWatch Log Group"
 }
+
+variable "auto_accept_shared_attachments" {
+  type        = string
+  default     = "disable"
+  description = "Whether resource attachment requests are automatically accepted."
+}

--- a/transit-gateway.tf
+++ b/transit-gateway.tf
@@ -3,7 +3,7 @@ resource "aws_ec2_transit_gateway" "default" {
 
   description                        = "${var.name}-transit-gateway"
   amazon_side_asn                    = var.transit_gateway_asn
-  auto_accept_shared_attachments     = "enable"
+  auto_accept_shared_attachments     = var.auto_accept_shared_attachments
   default_route_table_association    = var.default_route_table_association
   default_route_table_propagation    = var.default_route_table_propagation
   dns_support                        = var.dns_support


### PR DESCRIPTION
This change improves flexibility by allowing different environments to choose whether to auto-accept shared attachments instead of enforcing a hardcoded default.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...